### PR TITLE
require statsmodel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ folium==0.14.0
 altair==5.1.2
 plotly==5.18.0
 dill==0.3.7
+statsmodels


### PR DESCRIPTION
closes https://github.com/microbiomedata/notebook_hackathons/issues/26

For  block 8 of bioscales_biogeochemical_metadata/python/bioscales.ipynb:

```python
# Look at potassium vs. ph
fig = px.scatter(df, x="potassium", y="ph", trendline = "ols")
fig.show()
```